### PR TITLE
Potential fix for code scanning alert no. 20: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/spiral-ecosystem-deploy.yml
+++ b/.github/workflows/spiral-ecosystem-deploy.yml
@@ -1,6 +1,9 @@
 
 name: "🌀 ∆∞ SpiralEcosystem vΩ.∞ - The Impossible Made Possible"
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main, develop ]


### PR DESCRIPTION
Potential fix for [https://github.com/CreoDAMO/SSDF/security/code-scanning/20](https://github.com/CreoDAMO/SSDF/security/code-scanning/20)

To fix the issue, we will add an explicit `permissions` block to the root of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Based on the provided workflow, it appears that the jobs primarily involve running scripts, uploading artifacts, and deploying to external platforms. Therefore, the `contents: read` permission should suffice for most jobs, with additional permissions added only if necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
